### PR TITLE
Add support for non-standard ports

### DIFF
--- a/code/function-generation.lisp
+++ b/code/function-generation.lisp
@@ -484,8 +484,9 @@ symbols will have numbers values are converted into strings at run time.")
                 (,intern-response
                   (request
                    (render-uri
-	            (make-uri :scheme (uri-scheme ,intern-server-uri)
+                    (make-uri :scheme (uri-scheme ,intern-server-uri)
                               :host (uri-host ,intern-server-uri)
+                              :port (uri-port ,intern-server-uri)
                               :path ,uri-path
                               :query ,uri-query))
 	           ,@(if (member intern-content lambda-list)

--- a/code/openapi-generator.lisp
+++ b/code/openapi-generator.lisp
@@ -54,7 +54,7 @@
        (:import-from #:cl
                      #:append #:declaim #:declare #:ignorable #:optimize #:speed #:space #:safety #:debug #:compilation-speed #:defparameter #:null
                      #:case #:array #:write-to-string #:setf #:defparameter #:defun #:fdefinition #:t #:nil #:&key #:when #:let* #:or #:if #:cdr #:assoc #:quote #:string-equal #:cons #:list #:cond #:find #:warn #:boundp #:symbol-value #:string #:integer #:number #:boolean #:let #:unless #:make-string-output-stream #:get-output-stream-string #:string= #:hash-table #:stream #:typep #:progn #:ignore-errors #:stringp #:not #:otherwise)
-       (:import-from #:quri #:uri #:make-uri #:render-uri #:uri-scheme #:uri-host)
+       (:import-from #:quri #:uri #:make-uri #:render-uri #:uri-scheme #:uri-host #:uri-port)
        (:import-from #:str #:concat)
        (:import-from #:com.inuoe.jzon #:parse #:with-writer* #:write-key* #:write-value* #:stringify)
        (:import-from #:openapi-generator #:remove-empty-values #:json-null #:json-number #:json-array #:json-object #:json-false #:json-true)

--- a/code/package.lisp
+++ b/code/package.lisp
@@ -26,7 +26,7 @@
   (:import-from #:listopia
                 #:intersperse)
   (:import-from #:quri
-                #:uri #:uri-scheme #:uri-host #:uri-path
+                #:uri #:uri-scheme #:uri-host #:uri-port #:uri-path
                 #:make-uri #:render-uri #:merge-uris)
   (:import-from #:dexador
                 #:request)


### PR DESCRIPTION
Codeberg was giving me 500 errors when I tried to create a pull request, so I'll just have to do it here.

This patch is required to access servers on non-standard ports. eg: http://localhost:8080

Thank you!
